### PR TITLE
ランダムクエストのメッセージを種族毎で変えられるようにする+メッセージが表示されないバグを修正

### DIFF
--- a/lib/file/Makefile.am
+++ b/lib/file/Makefile.am
@@ -5,14 +5,14 @@ angband_files = \
 	aname_j.txt book-0_jp.txt chainswd_j.txt dead_j.txt \
 	death_j.txt elvish_j.txt error_j.txt mondeath_j.txt \
 	monfear_j.txt monfrien_j.txt monspeak_j.txt news_j.txt \
-	rumors_j.txt seppuku_j.txt silly_j.txt timefun_j.txt \
+	randomquest_j.txt rumors_j.txt seppuku_j.txt silly_j.txt timefun_j.txt \
 	timenorm_j.txt w_cursed_j.txt w_high_j.txt w_low_j.txt \
 	w_med_j.txt \
 	a_cursed.txt a_high.txt a_low.txt a_med.txt \
 	chainswd.txt dead.txt \
 	death.txt elvish.txt error.txt mondeath.txt \
 	monfear.txt monfrien.txt monspeak.txt news.txt \
-	rumors.txt seppuku.txt silly.txt sname.txt timefun.txt \
+	randomquest.txt rumors.txt seppuku.txt silly.txt sname.txt timefun.txt \
 	timenorm.txt w_cursed.txt w_high.txt w_low.txt\
 	w_med.txt
 

--- a/lib/file/randomquest.txt
+++ b/lib/file/randomquest.txt
@@ -1,0 +1,9 @@
+N:1351:GREAT THING, the Huge Battle Ship
+WARNING!! A HUGE BATTLESHIP GREAT THING IS APPROACHING FAST!
+
+N:1348:Mizuno Aoi
+N:1355:Cocoa, the chief of hell maids
+Destroy %s in this floor, it will gives you great rewards and the path of down-floor!
+
+N:*:Default line
+Beware, this level is protected by %s!

--- a/lib/file/randomquest_j.txt
+++ b/lib/file/randomquest_j.txt
@@ -1,0 +1,9 @@
+N:1351:巨大戦艦『グレート・シング』
+WARNING!! A HUGE BATTLESHIP GREAT THING IS APPROACHING FAST!
+
+N:1348:『ミズノアオイ』
+N:1355:魔界のメイド長『ココア』
+この階の%sを倒せば膨大な報酬と共に次の階への道が開かれるだろう！
+
+N:*:Default line
+注意せよ！この階は%sによって守られている！

--- a/src/dungeon/dungeon-processor.cpp
+++ b/src/dungeon/dungeon-processor.cpp
@@ -127,7 +127,7 @@ void process_dungeon(PlayerType *player_ptr, bool load_game)
     if (!player_ptr->playing || player_ptr->is_dead)
         return;
 
-    if (floor_ptr->quest_number != quest_id::NONE && (player_ptr->dungeon_idx == DUNGEON_ANGBAND)) {
+    if (floor_ptr->quest_number == quest_id::NONE && (player_ptr->dungeon_idx == DUNGEON_ANGBAND)) {
         quest_discovery(random_quest_number(player_ptr, floor_ptr->dun_level));
         floor_ptr->quest_number = random_quest_number(player_ptr, floor_ptr->dun_level);
     }

--- a/src/dungeon/quest.cpp
+++ b/src/dungeon/quest.cpp
@@ -9,6 +9,7 @@
 #include "floor/floor-object.h"
 #include "game-option/play-record-options.h"
 #include "grid/feature.h"
+#include "io/files-util.h"
 #include "io/write-diary.h"
 #include "locale/english.h"
 #include "main/music-definitions-table.h"
@@ -200,7 +201,10 @@ void quest_discovery(quest_id q_idx)
     bool is_random_quest_skipped = r_ptr->race_kind_flags.has(MonraceKindType::UNIQUE);
     is_random_quest_skipped &= r_ptr->max_num == 0;
     if (!is_random_quest_skipped) {
-        msg_format(_("注意せよ！この階は%sによって守られている！", "Beware, this level is protected by %s!"), name);
+        std::string line_got;
+        line_got.resize(1024);
+        if (get_rnd_line(_("randomquest_j.txt", "randomquest.txt"), q_ptr->r_idx, line_got.data()) == 0)
+            msg_format(line_got.c_str(), name);
         return;
     }
 


### PR DESCRIPTION
Resolved #134
Fixed #136
本家にも移植予定